### PR TITLE
refactor: use whiskers

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,5 @@
+_default:
+  @just --list
+
+build:
+  whiskers monkeytype.tera

--- a/monkeytype.tera
+++ b/monkeytype.tera
@@ -1,0 +1,19 @@
+---
+whiskers:
+  version: "2.2.0"
+  matrix:
+    - flavor
+  filename: "{{ flavor.identifier }}.css"
+---
+:root {
+    --bg-color: #{{ base.hex }};
+    --caret-color: #{{ rosewater.hex }};
+    --main-color: #{{ green.hex }};
+    --sub-color: #{{ surface2.hex }};
+    --sub-alt-color: #{{ mantle.hex }};
+    --text-color: #{{ text.hex }};
+    --error-color: #{{ red.hex }};
+    --error-extra-color: #{{ maroon.hex }};
+    --colorful-error-color: #{{ red.hex }};
+    --colorful-error-extra-color: #{{ maroon.hex }};
+   }


### PR DESCRIPTION
Adds [Whiskers](https://github.com/catppuccin/toolbox/tree/main/whiskers), Catppuccin's internal templating tool, to build the themes. Instead of editing the `.css` files directly, edit the `monketype.tera` file and then run `just build` to build the output themes. You will need Whiskers (linked above) and *optionally* [Just](https://github.com/casey/just) installed.

I've kept the changes here minimal to speed up the reviewing process, but this opens up the ability to add accents to the Whiskers matrix and remove the custom colors section from the README.